### PR TITLE
add openhab to filetype names

### DIFF
--- a/ftdetect/openhab.vim
+++ b/ftdetect/openhab.vim
@@ -5,8 +5,8 @@
 " URL:                  https://github.com/cyberkov/openhab-vim
 " ----------------------------------------------------------------------------
 
-au BufRead,BufNewFile *.items set filetype=items syntax=openhab
-au BufRead,BufNewFile *.rules set filetype=rules syntax=openhab
-au BufRead,BufNewFile *.persist set filetype=persist syntax=openhab
-au BufRead,BufNewFile *.sitemap set filetype=sitemap syntax=openhab
-au BufRead,BufNewFile *.things set filetype=things syntax=openhab
+au BufRead,BufNewFile *.items set filetype=openhab-items syntax=openhab
+au BufRead,BufNewFile *.rules set filetype=openhab-rules syntax=openhab
+au BufRead,BufNewFile *.persist set filetype=openhab-persist syntax=openhab
+au BufRead,BufNewFile *.sitemap set filetype=openhab-sitemap syntax=openhab
+au BufRead,BufNewFile *.things set filetype=openhab-things syntax=openhab

--- a/syntax/openhab.vim
+++ b/syntax/openhab.vim
@@ -30,7 +30,7 @@ hi def link  openhabBoolean     Boolean
 
 " .items File
 " ----------------------------------------------------------------------------
-if &filetype=='items'
+if &filetype=='openhab-items'
   " GroupItem
   syn  keyword openhabGroupitem Group
 
@@ -68,7 +68,7 @@ endif
 
 " .sitemap File
 " ----------------------------------------------------------------------------
-if &filetype=='sitemap'
+if &filetype=='openhab-sitemap'
   syn  keyword openhabModel sitemap
 
 " NonLinkableWidget
@@ -93,7 +93,7 @@ endif
 
 " .rules File
 " ----------------------------------------------------------------------------
-if &filetype=='rules'
+if &filetype=='openhab-rules'
 " Commands
   syn keyword  openhabCommand import var say if else switch case try catch finally println  or postUpdate sendCommand createTimer startTime endTime callScript executeCommandLine logDebug logInfo logWarn logError sendTelegram sendTweet sendMail notifyMyAndroid
 
@@ -141,7 +141,7 @@ endif
 
 " .persist File
 " ----------------------------------------------------------------------------
-if &filetype=='persist'
+if &filetype=='openhab-persist'
   syn keyword openhabModel Strategies Filters Items
   syn keyword openhabConfiguration strategy strategies default filter
   syn region openhabString      start=+"+ end=+"+
@@ -154,7 +154,7 @@ endif
 
 " .things File
 " ----------------------------------------------------------------------------
-if &filetype=='things'
+if &filetype=='openhab-things'
   syn region openhabThingConfig start=+\[+ end=+\]+ contains=openhabThingConfig_quote
   syn region openhabThingConfig_quote start=+"+ end=+"+
   syn keyword openhabThing Thing Bridge


### PR DESCRIPTION
The filetype names can be considered as too generic, so I added "openhab-", e.g. "openhab-things"