### PR TITLE
Added syntax highlighting for keyword "labelcolor"

### DIFF
--- a/syntax/openhab.vim
+++ b/syntax/openhab.vim
@@ -78,7 +78,7 @@ if &filetype=='openhab-sitemap'
   syn keyword  openhabLinkablewidget  Text Group Image Frame
 
 " Parameters
-  syn keyword  openhabParameter  name label item period refresh icon mappings minValue maxValue step switchsupport url encoding height refresh visibility valuecolor
+  syn keyword  openhabParameter  name label item period refresh icon mappings minValue maxValue step switchsupport url encoding height refresh visibility valuecolor labelcolor
 
   syn region openhabString      start=+"+ end=+"+
   syn region openhabString      start=+\[+ end=+\]+


### PR DESCRIPTION
- Syntax highlighting for the keyword "labelcolor" added.
- Tested
- See this [https://www.openhab.org/docs/configuration/sitemaps.html#label-and-value-colors](https://www.openhab.org/docs/configuration/sitemaps.html#label-and-value-colors)