### PR TITLE
Fix spelling of openHAB in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # openhab-vim
-Vim Syntax files for OpenHAB
+Vim syntax files for openHAB
 
 ### Installing the syntax-files
 #### Automatic installation


### PR DESCRIPTION
@cyberkov Can you update the repo "title" (the line above the tags) and add a link to https://www.openhab.org?
I'm not allowed to edit that.